### PR TITLE
add initial publish docker action

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -1,11 +1,8 @@
-name: testing actions
+name: publish docker on master merge
 
 on:
   push:
-    branches: [actions-sandbox]
-    paths:
-      - 'src/server/**'
-
+    branches: [master]
 
 jobs:
   run-actions:


### PR DESCRIPTION
Ok, this should be right. 

1) One action for master merges, for building docker integration
2) One action just for testing, for any pushes to the `actions-sandbox` branch