### PR TITLE
add env to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,14 @@ RUN npm install
 COPY . /chord-app/
 # Make port 8080 available to the world outside this container
 EXPOSE 8080
+#Env is required to persist variable into built image.
+#Docker run can now accept variable and it will be assigned here.
+#default is run in dev mode
+ENV run_mode_env=devNoClient
 # Run the app when the container launches
-CMD ["npm", "run", "devNoClient"]
+# Due to variable, CMD syntax must change for this to work https://stackoverflow.com/a/40454758
+CMD npm run $run_mode_env
+
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,12 @@ npm:
 node_dev:
 	echo 'Starting Node dev server in Docker Container'
 	docker build -t node_dev .
-	docker run -t -p 8080:8080 node_dev
+	docker run -it -p 8080:8080 node_dev
+
+node_prod:
+	echo 'Starting Node prod server in Docker Container'
+	docker build --build-arg run_mode_arg=start -t node_prod .
+	docker run -p 8080:8080 -e "run_mode_env=start" node_prod
 
 client:
 	echo 'Starting client'


### PR DESCRIPTION
This addresss #30 

added env to dockerfile so node can be run in dev or prod mod

comments in the dockerfile trying to explain the additions and changes

changed makefile  for dev and prod start option.   The env variable is passed in through `docker run` 