### PR TITLE
use V1 so dockerignore is realized

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -8,32 +8,18 @@ jobs:
   run-actions:
     runs-on: ubuntu-latest
     steps:
-      - name: Echo a string
-        run: echo "Lets go"
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build and push Docker images
+        id: docker_build
+        uses: docker/build-push-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v2
-        with:
-          push: true
-          tags: antonemery/chord-app:latest
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          repository: antonemery/chord-app
+          tags: latest
+
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
 
@@ -58,5 +44,3 @@ jobs:
             -p 8080:8080 \
             -e "run_mode_env=start" \
             antonemery/chord-app:latest
-
-


### PR DESCRIPTION
This should resolve #54 

Go back to using V1 of the docker action. Confirmed `dockerignore` is respected in the final image in Dockerhub

If action is successful, check app route on droplet returns expected string