### PR TITLE
publish only changes to server or dockerfile

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -3,6 +3,9 @@ name: publish docker on master merge
 on:
   push:
     branches: [master]
+    paths:
+      - 'src/Dockerfile'
+      - 'src/server/**'
 
 jobs:
   run-actions:


### PR DESCRIPTION
Publish action will run only if:

Dockerfile is changed
Or, any files in the server directory are changed

I didn't test it.  When this is merged, the publish action should not run