### PR TITLE
set cookie sameSite to strict. Add dev CLIENT_URL to README env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ docker system prune -a
 The Node backend uses a `variables.env` in `src/server` file to connect to the Mongo database and Mailtrap.io, a service used to test emails sent to users.  You will need to create that file and fill in your specific data.
 ````
 NODE_ENV=development
+CLIENT_URL=http://localhost:3000/
 DATABASE=mongodb address and credentials
 MAIL_USER=mailtrap.io user
 MAIL_PASS=mailtraip.io password

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -36,7 +36,7 @@ app.use(session({
   resave: false,
   saveUninitialized: false,
   store: new MongoStore({ mongooseConnection: mongoose.connection }),
-  cookie: { secure: false, httpOnly: false, maxAge: 600000000 }
+  cookie: { sameSite: 'strict', secure: false, httpOnly: false, maxAge: 600000000 }
 }))
 
 // promisify some callback based APIs


### PR DESCRIPTION
For #61 

this helped
https://stackoverflow.com/questions/61999068/how-do-i-use-cookies-in-express-session-connect-sid-will-soon-be-rejected

express cookie docs
http://expressjs.com/en/resources/middleware/session.html

I tested locally to first produce the warning but it did not happen for me. I can't say for certain this resolves it. 

Without this change, I also tested from netlify to deployed backend and I did not see cookie warning mentioned in the issue when I logged in. 🤷  Where would the warning pop up?

